### PR TITLE
Remove downloading model&data in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,8 +26,6 @@ run apt-get update && apt-get install -y \
 wget \
 unzip
 
-run python3 runGan.py 0
-
 run apt-get update && apt-get install -y \
 libsm6 \
 libxrender1 \


### PR DESCRIPTION
I removed `python3 runGan.py 0` (downloading model and data) from Dockerfile because of the following issues.
1. As host directory is mounted to `/TecoGAN` when making container, users can't see downloaded models and dataset
`docker run --gpus all -it --mount src=$(pwd),target=/TecoGAN,type=bind -w /TecoGAN tecogan_image bash`
https://github.com/ryul99/TecoGAN#3-start-the-docker-container-we-just-build
2. Also, I think not every user needs test data or pretrained model and downloading these could be time-consuming when building an image and makes image size bigger. But this is a minor issue than the first issue. If there is a way to solve only the first issue, I think that also could be a good way. 